### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python game.py"

--- a/README.rst
+++ b/README.rst
@@ -5,3 +5,5 @@ https://github.com/myrmica-habilis/cave-terror
 Working title is *Strach ze tmy* ("Fear of the Dark").
 
 It is still work-in-progress, being continuously refactored and extended.
+
+[![Run on Repl.it](https://repl.it/badge/github/myrmica-habilis/SzT)](https://repl.it/github/myrmica-habilis/SzT)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@myrmica/SzT).